### PR TITLE
Fix WebSocket connection cleanup to prevent 429 errors

### DIFF
--- a/backend/routes/v1/index.js
+++ b/backend/routes/v1/index.js
@@ -6,6 +6,7 @@ import lightsRouter from './lights.js';
 import roomsRouter from './rooms.js';
 import zonesRouter from './zones.js';
 import scenesRouter from './scenes.js';
+import statsRouter from './stats.js';
 
 const router = express.Router();
 
@@ -17,5 +18,6 @@ router.use('/lights', lightsRouter);
 router.use('/rooms', roomsRouter);
 router.use('/zones', zonesRouter);
 router.use('/scenes', scenesRouter);
+router.use('/stats', statsRouter);
 
 export default router;

--- a/backend/routes/v1/stats.js
+++ b/backend/routes/v1/stats.js
@@ -1,0 +1,18 @@
+import express from 'express';
+import websocketService from '../../services/websocketService.js';
+
+const router = express.Router();
+
+/**
+ * GET /api/v1/stats/websocket
+ * Get WebSocket connection statistics for debugging
+ */
+router.get('/websocket', (req, res) => {
+  const stats = websocketService.getStats();
+  res.json({
+    ...stats,
+    timestamp: new Date().toISOString()
+  });
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- Add periodic cleanup (every 60s) for orphaned polling intervals
- Clean up stale connections not in OPEN state  
- Call handleDisconnect before terminating unresponsive clients
- Add detailed logging for connection lifecycle events
- Add `/api/v1/stats/websocket` endpoint for monitoring
- Increase poll interval to 15 seconds

## Root Cause
429 errors were caused by orphaned polling intervals that accumulated when:
- WebSocket connections didn't close cleanly (browser closed, network issues)
- Multiple browser tabs opened separate connections
- `handleDisconnect` wasn't called, leaving orphan polling intervals

## Test plan
- [x] All 135 backend tests passing
- [ ] Monitor `/api/v1/stats/websocket` endpoint after deployment
- [ ] Verify connection count matches expected (1 per active client)
- [ ] Verify polling intervals are cleaned up when clients disconnect
- [ ] Confirm 429 errors no longer occur under normal usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)