### PR TITLE
Upgrade to React 19

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,13 +17,14 @@
     "test:e2e:headed": "playwright test --headed"
   },
   "dependencies": {
+    "@testing-library/dom": "^10.4.1",
     "axios": "^1.13.2",
     "loglevel": "^1.9.2",
     "lucide-react": "^0.562.0",
     "openmeteo": "^1.2.3",
     "prop-types": "^15.8.1",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1",
+    "react": "^19.2.3",
+    "react-dom": "^19.2.3",
     "socket.io-client": "^4.8.3"
   },
   "devDependencies": {

--- a/frontend/src/components/Dashboard/index.test.jsx
+++ b/frontend/src/components/Dashboard/index.test.jsx
@@ -328,13 +328,14 @@ describe('Dashboard', () => {
       const user = userEvent.setup();
       render(<Dashboard sessionToken="test-token" />);
 
+      // Wait for RoomContent to render (scene drawer trigger indicates room is loaded)
+      let drawerTrigger;
       await waitFor(() => {
-        expect(screen.getByText('Living Room')).toBeInTheDocument();
+        drawerTrigger = document.querySelector('.scene-drawer-trigger');
+        expect(drawerTrigger).toBeTruthy();
       });
 
       // Open the scene drawer
-      const drawerTrigger = document.querySelector('.scene-drawer-trigger');
-      expect(drawerTrigger).toBeTruthy();
       await user.click(drawerTrigger);
 
       // Find toggle button in drawer
@@ -356,12 +357,14 @@ describe('Dashboard', () => {
 
       render(<Dashboard sessionToken="test-token" />);
 
+      // Wait for RoomContent to render
+      let drawerTrigger;
       await waitFor(() => {
-        expect(screen.getByText('Living Room')).toBeInTheDocument();
+        drawerTrigger = document.querySelector('.scene-drawer-trigger');
+        expect(drawerTrigger).toBeTruthy();
       });
 
       // Open the scene drawer
-      const drawerTrigger = document.querySelector('.scene-drawer-trigger');
       await user.click(drawerTrigger);
 
       const toggleButton = document.querySelector('.scene-drawer-toggle');
@@ -378,12 +381,14 @@ describe('Dashboard', () => {
       const user = userEvent.setup();
       render(<Dashboard sessionToken="test-token" />);
 
+      // Wait for RoomContent to render
+      let drawerTrigger;
       await waitFor(() => {
-        expect(screen.getByText('Living Room')).toBeInTheDocument();
+        drawerTrigger = document.querySelector('.scene-drawer-trigger');
+        expect(drawerTrigger).toBeTruthy();
       });
 
       // Open the scene drawer
-      const drawerTrigger = document.querySelector('.scene-drawer-trigger');
       await user.click(drawerTrigger);
 
       // Find scene button in drawer
@@ -400,12 +405,14 @@ describe('Dashboard', () => {
       const user = userEvent.setup();
       render(<Dashboard sessionToken="test-token" />);
 
+      // Wait for RoomContent to render
+      let drawerTrigger;
       await waitFor(() => {
-        expect(screen.getByText('Living Room')).toBeInTheDocument();
+        drawerTrigger = document.querySelector('.scene-drawer-trigger');
+        expect(drawerTrigger).toBeTruthy();
       });
 
       // Open the scene drawer
-      const drawerTrigger = document.querySelector('.scene-drawer-trigger');
       await user.click(drawerTrigger);
 
       const sceneItems = document.querySelectorAll('.scene-drawer-item');
@@ -422,12 +429,14 @@ describe('Dashboard', () => {
 
       render(<Dashboard sessionToken="test-token" />);
 
+      // Wait for RoomContent to render
+      let drawerTrigger;
       await waitFor(() => {
-        expect(screen.getByText('Living Room')).toBeInTheDocument();
+        drawerTrigger = document.querySelector('.scene-drawer-trigger');
+        expect(drawerTrigger).toBeTruthy();
       });
 
       // Open the scene drawer
-      const drawerTrigger = document.querySelector('.scene-drawer-trigger');
       await user.click(drawerTrigger);
 
       const sceneItems = document.querySelectorAll('.scene-drawer-item');

--- a/frontend/src/hooks/useSettings.test.js
+++ b/frontend/src/hooks/useSettings.test.js
@@ -342,11 +342,11 @@ describe('useSettings', () => {
 
       rerender({ enabled: true });
 
+      // Wait for both the API call AND the state update to complete
       await waitFor(() => {
         expect(settingsApi.getSettings).toHaveBeenCalledWith(false);
+        expect(result.current.settings).toEqual({ ...mockSettings, services: defaultServices });
       });
-
-      expect(result.current.settings).toEqual({ ...mockSettings, services: defaultServices });
     });
   });
 

--- a/frontend/src/integration.test.jsx
+++ b/frontend/src/integration.test.jsx
@@ -495,17 +495,14 @@ describe('Integration Tests', () => {
       await waitFor(() => screen.getByText(new RegExp(UI_TEXT.AUTH_TITLE, 'i')));
       await user.click(screen.getByText(new RegExp(UI_TEXT.BUTTON_I_PRESSED_BUTTON, 'i')));
 
-      // Wait for WebSocket to connect and receive data
+      // Wait for WebSocket to connect and receive data (wait for lights to render)
       await waitFor(
         () => {
-          expect(screen.getByText('Living Room')).toBeInTheDocument();
+          expect(screen.getByText('Light 1')).toBeInTheDocument();
+          expect(screen.getByText('Light 2')).toBeInTheDocument();
         },
         { timeout: 10000 }
       );
-
-      // Verify dashboard loaded via WebSocket
-      expect(screen.getByText('Light 1')).toBeInTheDocument();
-      expect(screen.getByText('Light 2')).toBeInTheDocument();
     });
 
     it('does not show error flash during initial connection', async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,13 +54,14 @@
       "name": "home-control-frontend",
       "version": "1.0.0",
       "dependencies": {
+        "@testing-library/dom": "^10.4.1",
         "axios": "^1.13.2",
         "loglevel": "^1.9.2",
         "lucide-react": "^0.562.0",
         "openmeteo": "^1.2.3",
         "prop-types": "^15.8.1",
-        "react": "^18.3.1",
-        "react-dom": "^18.3.1",
+        "react": "^19.2.3",
+        "react-dom": "^19.2.3",
         "socket.io-client": "^4.8.3"
       },
       "devDependencies": {
@@ -258,7 +259,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
       "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.27.1",
@@ -505,7 +505,6 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -744,7 +743,6 @@
       "version": "7.28.4",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
       "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -2855,7 +2853,6 @@
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -2945,7 +2942,6 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/babel__core": {
@@ -3332,7 +3328,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3364,7 +3359,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "dequal": "^2.0.3"
@@ -4359,7 +4353,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4411,7 +4404,6 @@
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/dunder-proto": {
@@ -6927,7 +6919,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "lz-string": "bin/bin.js"
@@ -7781,7 +7772,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -7899,7 +7889,6 @@
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1",
@@ -7914,7 +7903,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -7927,7 +7915,6 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/pretty-ms": {
@@ -8036,30 +8023,26 @@
       }
     },
     "node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
+      "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
       "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
+        "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^18.3.1"
+        "react": "^19.2.3"
       }
     },
     "node_modules/react-is": {
@@ -8408,13 +8391,10 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -10108,6 +10088,24 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",


### PR DESCRIPTION
## Summary
- Upgrades React and React-DOM from 18.x to 19.2.3
- Fixes test compatibility issues caused by React 19's batched state updates
- All 895 tests pass

## Changes
- Dashboard tests now wait for `RoomContent` to fully render before interacting with scene drawer elements
- `useSettings` test waits for both API call AND state update completion
- Integration test waits for lights to render rather than just room name

## Test plan
- [x] All unit tests pass (895 tests)
- [ ] E2E tests pass
- [ ] Manual testing of the app

This PR supersedes and properly combines the changes from Dependabot PRs #10 and #12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)