### PR TITLE
Fix Codecov integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: frontend/coverage/lcov.info
           flags: frontend
           fail_ci_if_error: false
@@ -78,6 +79,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: backend/coverage/lcov.info
           flags: backend
           fail_ci_if_error: false

--- a/backend/vitest.config.js
+++ b/backend/vitest.config.js
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html', 'lcov'],
+      exclude: ['node_modules/', 'test/', '**/*.config.js'],
+    },
+  },
+});

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -10,7 +10,7 @@ export default defineConfig({
     exclude: ['**/node_modules/**', '**/dist/**', '**/.stryker-tmp/**', '**/e2e/**'],
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'json', 'html'],
+      reporter: ['text', 'json', 'html', 'lcov'],
       exclude: ['node_modules/', 'src/test/', '**/*.config.js', 'dist/', '.stryker-tmp/'],
     },
   },


### PR DESCRIPTION
## Summary
- Add lcov reporter to vitest configs (required format for Codecov)
- Add CODECOV_TOKEN to CI workflow for protected branch uploads
- Create backend/vitest.config.js for coverage settings

## Setup Required
Add `CODECOV_TOKEN` secret to GitHub repo:
1. Go to [codecov.io](https://codecov.io) → Settings → Upload Token
2. Add to GitHub: Settings → Secrets → Actions → New: `CODECOV_TOKEN`

## Test plan
- [ ] Add CODECOV_TOKEN secret
- [ ] CI uploads coverage successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)