### PR TITLE
Improve Hue bridge page responsiveness

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1558,6 +1558,29 @@ button.secondary:hover:not(:disabled) {
     padding: 8px 14px;
     font-size: 0.9rem;
   }
+
+  /* Bridge pages - wider on tablets */
+  .bridge-discovery,
+  .authentication {
+    max-width: 700px;
+  }
+}
+
+/* Very narrow screens - hide progress step labels */
+@media (max-width: 360px) {
+  .step-label {
+    display: none;
+  }
+
+  .step-number {
+    width: 32px;
+    height: 32px;
+    font-size: 0.9rem;
+  }
+
+  .progress-line {
+    width: 30px;
+  }
 }
 
 /* Motion Alert Flash Notification */


### PR DESCRIPTION
## Summary
- Increase max-width to 700px on tablets (768-1200px) for bridge discovery and authentication pages
- Hide progress step labels on very narrow screens (≤360px)
- Reduce step number and progress line sizes on narrow screens

## Test plan
- [x] Verified with screenshots at iPad portrait (768px) - content is now wider
- [x] Verified with screenshots at 320px width - step labels hidden, numbers only
- [x] All 938 frontend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)