### PR TITLE
Add Codecov Test Analytics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,14 @@ jobs:
           flags: frontend
           fail_ci_if_error: false
 
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: frontend/test-results/junit.xml
+          flags: frontend
+
   test-backend:
     name: Backend Tests
     runs-on: ubuntu-latest
@@ -83,6 +91,14 @@ jobs:
           files: backend/coverage/lcov.info
           flags: backend
           fail_ci_if_error: false
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: backend/test-results/junit.xml
+          flags: backend
 
   test-e2e:
     name: E2E Tests

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ frontend/playwright/.cache
 backend/coverage
 backend/reports
 backend/.stryker-tmp
+backend/test-results
 
 # Editor directories and files
 .vscode/*

--- a/backend/vitest.config.js
+++ b/backend/vitest.config.js
@@ -3,6 +3,10 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     globals: true,
+    reporters: ['default', 'junit'],
+    outputFile: {
+      junit: './test-results/junit.xml',
+    },
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html', 'lcov'],

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -8,6 +8,10 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: './src/test/setup.js',
     exclude: ['**/node_modules/**', '**/dist/**', '**/.stryker-tmp/**', '**/e2e/**'],
+    reporters: ['default', 'junit'],
+    outputFile: {
+      junit: './test-results/junit.xml',
+    },
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html', 'lcov'],


### PR DESCRIPTION
## Summary

- Configure Vitest to output JUnit XML reports for both frontend and backend
- Add `codecov/test-results-action@v1` to CI workflow to upload test results
- Test results uploaded even when tests fail (using `if: ${{ !cancelled() }}`)

## Features Enabled

Once merged, Codecov will provide:
- Test run duration and failure rate analytics
- PR comments showing failed tests with stack traces
- Flaky test detection on main branch

## Files Changed

| File | Change |
|------|--------|
| `frontend/vitest.config.js` | Added JUnit reporter |
| `backend/vitest.config.js` | Added JUnit reporter |
| `.github/workflows/ci.yml` | Added test results upload steps |
| `.gitignore` | Added `backend/test-results` |

## Note

Bundle analysis not included - `@codecov/vite-plugin` only supports Vite 4-6, project uses Vite 7.

## Test plan

- [ ] CI workflow runs successfully
- [ ] Test results appear in Codecov dashboard
- [ ] JUnit XML files generated locally with `npm run test:run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)