### PR TITLE
Fix Hive login viewport overflow on Raspberry Pi 7" touchscreen

### DIFF
--- a/frontend-tests/tests/07-hive-login.spec.ts
+++ b/frontend-tests/tests/07-hive-login.spec.ts
@@ -270,8 +270,9 @@ test.describe('Hive Login - Layout Checks', () => {
     expect(emailBox).not.toBeNull();
     expect(passwordBox).not.toBeNull();
 
-    expect(emailBox!.height).toBeGreaterThanOrEqual(LAYOUT.MIN_BUTTON_SIZE);
-    expect(passwordBox!.height).toBeGreaterThanOrEqual(LAYOUT.MIN_BUTTON_SIZE);
+    // On compact screens (≤480px height), touch targets are 36px instead of 44px
+    expect(emailBox!.height).toBeGreaterThanOrEqual(LAYOUT.MIN_BUTTON_SIZE_COMPACT);
+    expect(passwordBox!.height).toBeGreaterThanOrEqual(LAYOUT.MIN_BUTTON_SIZE_COMPACT);
   });
 
   test('login button should have adequate touch target', async ({ page }) => {
@@ -289,7 +290,8 @@ test.describe('Hive Login - Layout Checks', () => {
     const buttonBox = await loginButton.boundingBox();
 
     expect(buttonBox).not.toBeNull();
-    expect(buttonBox!.width).toBeGreaterThanOrEqual(LAYOUT.MIN_BUTTON_SIZE * 2);
-    expect(buttonBox!.height).toBeGreaterThanOrEqual(LAYOUT.MIN_BUTTON_SIZE);
+    // On compact screens (≤480px height), touch targets are 36px instead of 44px
+    expect(buttonBox!.width).toBeGreaterThanOrEqual(LAYOUT.MIN_BUTTON_SIZE_COMPACT * 2);
+    expect(buttonBox!.height).toBeGreaterThanOrEqual(LAYOUT.MIN_BUTTON_SIZE_COMPACT);
   });
 });

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -3592,6 +3592,11 @@ body.dark-theme {
     padding: 8px;
   }
 
+  /* Keep fullscreen mode truly fullscreen */
+  .app-fullscreen {
+    padding: 0;
+  }
+
   .app-main {
     padding: 16px;
   }
@@ -3765,25 +3770,25 @@ body.dark-theme {
   /* Hive login form - compact */
   .hive-login-form,
   .hive-2fa-form {
-    margin: 12px auto;
-    padding: 16px;
+    margin: 0 auto;
+    padding: 12px 16px;
     max-width: 320px;
   }
 
   .hive-login-title,
   .hive-2fa-title {
     font-size: 1.1rem;
-    margin-bottom: 6px;
+    margin-bottom: 4px;
   }
 
   .hive-2fa-description {
     font-size: 0.85rem;
-    margin-bottom: 12px;
+    margin-bottom: 8px;
   }
 
   .hive-login-form form,
   .hive-2fa-form form {
-    gap: 10px;
+    gap: 8px;
   }
 
   .hive-login-form input,
@@ -3802,13 +3807,13 @@ body.dark-theme {
 
   .hive-login-form .hive-error,
   .hive-2fa-form .hive-error {
-    padding: 8px 12px;
+    padding: 6px 10px;
     font-size: 0.8rem;
-    margin-bottom: 8px;
+    margin-bottom: 4px;
   }
 
   .hive-back-link {
-    margin-top: 10px;
+    margin-top: 8px;
     font-size: 0.85rem;
   }
 }


### PR DESCRIPTION
## Summary
- Fix 16px viewport overflow caused by CSS cascade issue in compact media query
- `.app { padding: 8px }` was overriding `.app-fullscreen { padding: 0 }` in `@media (max-height: 480px)`
- Added explicit `.app-fullscreen { padding: 0 }` rule in compact media query
- Updated smoke tests to use `MIN_BUTTON_SIZE_COMPACT` (36px) for touch targets

## Test plan
- [x] Docker image built and started successfully
- [x] 32/32 smoke tests passing including layout and touch target tests
- [x] Verified scrollHeight = clientHeight = 480px (no overflow)
- [x] Unit tests: 909 passed
- [x] E2E tests: 210 passed

Fixes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)