### PR TITLE
Fix Home API toggle failures

### DIFF
--- a/backend/services/deviceNormalizer.js
+++ b/backend/services/deviceNormalizer.js
@@ -110,14 +110,14 @@ export function normalizeHiveHotWater(hiveHotWater) {
 
 /**
  * Normalize a dashboard light object to unified device format
- * @param {Object} light - Dashboard light object (pre-processed format)
+ * @param {Object} light - Dashboard light object (pre-processed format from enrichLight)
  * @returns {Object} Normalized device
  */
 export function normalizeDashboardLight(light) {
-  const slug = slugMappingService.getSlug('hue', light.id, light.name);
-
+  // Light is already enriched with slug as id and _uuid from enrichLight()
+  // Do NOT call slugMappingService.getSlug() here - it would create corrupt mappings
   const device = createDevice({
-    id: slug,
+    id: light.id,
     name: light.name,
     type: DeviceTypes.LIGHT,
     serviceId: 'hue',
@@ -130,7 +130,7 @@ export function normalizeDashboardLight(light) {
   });
 
   // Preserve original UUID for reference (internal use only)
-  device._uuid = light.id;
+  device._uuid = light._uuid;
 
   return device;
 }


### PR DESCRIPTION
## Summary

Fixes #35 - Home API toggle failures caused by two bugs:

- **Bug 1: Slug mapping corruption** - `normalizeDashboardLight()` was calling `slugMappingService.getSlug()` on pre-enriched data, creating corrupt mappings (slug → slug instead of UUID → slug). Fixed by not calling `getSlug()` on already-enriched lights and properly preserving `_uuid`.

- **Bug 2: Room ID mismatch** - `updateRoomDevices()` wasn't resolving home room IDs (e.g., `home-living-room`) to service room IDs. Fixed by using `roomMappingService.getServiceRoomIds()` with fallback for V1-style IDs from WebSocket.

## Test plan

- [x] Unit tests added for both bug fixes
- [x] All 914 tests pass
- [x] Verified room toggle works (living room "all off/on")
- [x] Verified individual light toggle works after clearing corrupted slug mappings
- [x] Tested with production Docker image against real Hue Bridge

🤖 Generated with [Claude Code](https://claude.com/claude-code)